### PR TITLE
feat: Se agregó un apartado en test e2e para corroborar que el mensaj…

### DIFF
--- a/tests/e2e/specs/cart.spec.js
+++ b/tests/e2e/specs/cart.spec.js
@@ -53,4 +53,14 @@ describe('Cart', () => {
         cy.get('.product:nth-child(2) [data-testid="discount"]')
             .should('have.text', '10 %')
     });
+
+    it('Deberia mostrar un mensaje si el carrito no contiene ningín Item', () => {
+        cy.visit('/cart');
+
+        cy.get('h2').should(
+            'contain.text',
+            'No posee productos en el carrito'
+        );
+    });
+
 });


### PR DESCRIPTION
…e de carrito vacío aparezca

Se modificó el test e2e para que valide que, en caso de que el carrito esté vacio, se muestre en pantalla un mensaje.
Aguardo comentarios o merge de PR.